### PR TITLE
Encoding the page response in 'binary' so consumer could decode in non-nodejs charsets

### DIFF
--- a/lib/j-distiller.js
+++ b/lib/j-distiller.js
@@ -71,7 +71,8 @@
     
     this.request({
       url: url,
-      followAllRedirects: true
+      followAllRedirects: true,
+      encoding: 'binary'
     }, function(err, res, page) {
       
       if (!res) {
@@ -84,7 +85,7 @@
         callback(err, null);
         return;
       }
-      
+       
       _this._applyDSL(_this._getJQueryObject(page), callback);
     });
   };


### PR DESCRIPTION
In order to support non-nodejs charset like 'GBK' we need to encode the page response in 'binary' so consumer could decode the strings correctly. An example as in routers-news:

var title = iconv.decode(element.text(), 'gb2312');
